### PR TITLE
show subscribed shared folders only

### DIFF
--- a/www/modules/email/model/ImapMailbox.php
+++ b/www/modules/email/model/ImapMailbox.php
@@ -405,8 +405,11 @@ class ImapMailbox extends \GO\Base\Model {
 	 * @return boolean
 	 */
 	public function isVisible(){
-//		return $this->subscribed || ($this->nonexistent && $this->haschildren);
-
-		return $this->subscribed ||  $this->getHasChildren(true);
-	}
+                $imap = $this->getAccount()->openImapConnection();
+                if ($imap->has_capability("LIST-EXTENDED")) {
+                        return $this->subscribed;
+                } else {
+                        return $this->subscribed ||  $this->getHasChildren(true);
+                }
+	}	
 }


### PR DESCRIPTION
hide all unsubscribed shared folders inside the tree-panel when the imap server supports the LIST-EXTENDED capability
tested with dovecot-2.3.0