### PR TITLE
Replace &euro; with € in mail subject

### DIFF
--- a/www/modules/email/controller/MessageController.php
+++ b/www/modules/email/controller/MessageController.php
@@ -380,9 +380,7 @@ Settings -> Accounts -> Double click account -> Folders.", "email");
 			if(empty($record['subject']))
 				$record['subject']=GO::t("No subject", "email");
 			else
-				$record['subject'] = htmlspecialchars($record['subject'],ENT_COMPAT,'UTF-8');
-
-
+				$record['subject'] =  htmlspecialchars(str_replace('&euro;', '€', $record['subject']),ENT_COMPAT,'UTF-8');
 
 			$response["results"][]=$record;
 		}
@@ -1510,8 +1508,9 @@ Settings -> Accounts -> Double click account -> Folders.", "email");
 			$response = $this->_handleInvitations($imapMessage, $params, $response);
 			
 		}
-		
-		$response['isInSpamFolder']=$this->_getSpamMoveMailboxName($params['uid'],$params['mailbox'],$account->id);
+        $response['subject'] =  htmlspecialchars(str_replace('&euro;', '€', $response['subject']),ENT_COMPAT,'UTF-8');
+
+        $response['isInSpamFolder']=$this->_getSpamMoveMailboxName($params['uid'],$params['mailbox'],$account->id);
 		$response = $this->_getContactInfo($imapMessage, $params, $response, $account);
 
 		// START Handle the links div in the email display panel		

--- a/www/modules/email/model/Message.php
+++ b/www/modules/email/model/Message.php
@@ -367,7 +367,7 @@ abstract class Message extends \GO\Base\Model {
 		}
 
 		if($useHtmlSpecialChars){
-			$response['subject'] = htmlspecialchars($this->subject,ENT_COMPAT,'UTF-8');
+            $response['subject'] = htmlspecialchars(str_replace('&euro;', '€', $this->subject),ENT_COMPAT,'UTF-8');
 		} else {
 			$response['subject'] = $this->subject;
 		}


### PR DESCRIPTION
When in the mail subject there is an € sign this will be displayed as "\&euro;". This patch resolves this.