### PR TITLE
Update Instance.php

### DIFF
--- a/www/go/modules/community/multi_instance/model/Instance.php
+++ b/www/go/modules/community/multi_instance/model/Instance.php
@@ -192,9 +192,15 @@ class Instance extends Entity {
 		return str_replace('-', "", explode(".", $this->hostname)[0]);
 	}
 	
-	private function getDbUser() {
-		return substr($this->getDbName(), 0, 16);
+	private function getDbUser() {		
+		return substr($this->getDbName(), 0, 10).rand(5, 9999);
 	}
+	
+        private function getDbUserFromConfig() {
+                $config=$this->getInstanceConfig();
+                return $config["db_user"];
+        }
+
 	
 	protected function internalSave() {		
 		
@@ -696,8 +702,8 @@ class Instance extends Entity {
 					$dest = $dest->getParent()->getFolder($instance->getDataFolder()->getName() . '-' . uniqid());
 				}
 				$instance->getDataFolder()->move($dest);
-			
-				$instance->dropDatabaseUser($instance->getDbUser());
+							
+				$instance->dropDatabaseUser($instance->getDbUserFromConfig());
 				$instance->dropDatabase($instance->getDbName());
 			}catch(Exception $e) {
 				ErrorHandler::log("Error deleting instance: ". $instance->hostname);


### PR DESCRIPTION
MySQL has a username limit of 16 characters so if an instance has the same first 16 characters as another one, it will cause username collision.

This patch attempts to fix this case