### PR TITLE
Add STARTTLS support to IMAP Authenticator module

### DIFF
--- a/www/go/modules/community/imapauthenticator/model/Authenticator.php
+++ b/www/go/modules/community/imapauthenticator/model/Authenticator.php
@@ -44,10 +44,14 @@ class Authenticator extends PrimaryAuthenticator {
 		go()->debug("Attempting IMAP authentication on ".$server->imapHostname);
 		
 		$connection = new Connection();
-		if(!$connection->connect($server->imapHostname, $server->imapPort, $server->imapEncryption == 'ssl')) {
+		if(!$response = $connection->connect($server->imapHostname, $server->imapPort, $server->imapEncryption == 'ssl')) {
 			throw new Exception("Could not connect to IMAP server");
 		}
 		
+                if(strpos($response, 'STARTTLS') && $connection->startTLS()) {
+                        $server->imapEncryption = 'tls';
+                }
+
 		$imapUsername = $server->removeDomainFromUsername ? explode('@', $username)[0] : $username;
 		
 		if(!$connection->authenticate($imapUsername, $password)) {


### PR DESCRIPTION
When connecting to port 143, the IMAP Authenticator module attempts plaintext authentication over a non-TLS connection, even if the server doesn't announce this as a supported authentication type, and does not attempt to set up a TLS session using STARTTLS if the server announces it.

This patch checks the server connection string for STARTTLS support and attempts to initiate a TLS session if supported. If the session negotiation is successful, it sets the connection encryption type to TLS (which lines up with the IMAP configuration in the e-mail module) and continues