### PR TITLE
Add JWT capability to jitsimeet module

### DIFF
--- a/www/modules/jitsimeet/model/Settings.php
+++ b/www/modules/jitsimeet/model/Settings.php
@@ -12,6 +12,21 @@ class Settings extends core\Settings
 	 */
 	public $jitsiUri = 'https://meet.jit.si/';
 
+	/**
+	 * @var boolean
+	 */
+	public $jitsiJwtEnabled = false;
+	
+	/**
+	 * @var string
+	 */
+	public $jitsiJwtSecret = ''; //TODO: jitsiJwtSecret is leaked on the client side! I dont know how to prevent that...
+	
+	/**
+	 * @var string
+	 */
+	public $jitsiJwtAppId = '';
+	
 	protected function getModulePackageName(): ?string
 	{
 		return null; // backwards compat

--- a/www/modules/jitsimeet/views/Extjs3/PluginCalendar.js
+++ b/www/modules/jitsimeet/views/Extjs3/PluginCalendar.js
@@ -22,7 +22,7 @@ GO.mainLayout.on('authenticated', function() {
 
 							const form = this.findParentByType("form").form,
 								descriptionField = form.findField('description'),
-								jitsiLink = meetUri+(Math.random() + 1).toString(36).substring(2);
+								jitsiLink = meetUri + btn._jitsiRoom;
 
 							const desc = descriptionField.getValue();
 							descriptionField.setValue((desc ? desc + "\n" : "") + t("Online meeting link", "jitsimeet") + ":\n\n" + jitsiLink + "\n\n");
@@ -38,8 +38,9 @@ GO.mainLayout.on('authenticated', function() {
 
 			}),
 			setData : GO.calendar.EventDialog.prototype.setData.createSequence(function(action){
-				//console.log(action.result.data.jitsiMeet);
 				this.jitsiButton.setDisabled(action.result.data.jitsiMeet);
+				//I am sure there is a better place to store this - but I dont know the framework well enough:
+				this.jitsiButton._jitsiRoom = action.result.data.jitsiRoom;
 			})
 
 		});

--- a/www/modules/jitsimeet/views/Extjs3/SystemSettingsPanel.js
+++ b/www/modules/jitsimeet/views/Extjs3/SystemSettingsPanel.js
@@ -21,6 +21,31 @@ GO.jitsimeet.SystemSettingsPanel = Ext.extend(go.systemsettings.Panel, {
                         },
                     ]
                 },
+                {
+                    xtype: 'fieldset',
+                    title: t('JWT authentification'),
+                    defaults: {
+                        anchor: '100%',
+                    },
+                    items: [
+                        {
+                            hideLabel: true,
+                            xtype: "checkbox",
+                            boxLabel: t("Enable JWT authentification"),
+                            name: "jitsiJwtEnabled"
+                        },
+                        {
+                            xtype: 'textfield',
+                            fieldLabel: t('App Secret', 'jitsimeet', 'legacy'),
+                            name: 'jitsiJwtSecret',
+                        },
+                        {
+                            xtype: 'textfield',
+                            fieldLabel: t('App ID', 'jitsimeet', 'legacy'),
+                            name: 'jitsiJwtAppId',
+                        },
+                    ]
+                },
             ]
         });
 


### PR DESCRIPTION
I added an option for JWT authentification to the jitsimeet module. It slightly changes the behaviour when creating an event: Instead of generating a room code on the client side, it pregenerates it on the server (this is needed to not having to pass the JWT secret to the client).
I have tested it on my end and seems to work quite well.

**There is one issue that I am not able to solve myself but might need fixing:**
The JWT secret is leaked to groupoffice users if they run `go.Modules.get('legacy','jitsimeet').settings.jitsiJwtSecret` in their JavaScript console.
Is there any way to prevent specific settings to be passed over to the client / JavaScript side?

I was also experimenting with using `go.Jmap.request` to directly ask the server to generate a room code. But the server would always reply with `Bad request. Controller XXX not found`. I think its because jitsimeet is a legacy plugin and uses an old namespace (and I was not able to figure out the correct method string).


**For debugging:**
If you want to check the validity of the resulting JWT token, you can paste it to https://jwt.io/ (and provide the app secret set in the settings).

If you want to test JWT authentification with jitsi, you need to set up a jitsi instance with the following environment variables (using docker might be the easiest one):

(replacing [APP_SECRET] and [APP_ID]
```
ENABLE_AUTH=1
AUTH_TYPE=jwt
JWT_APP_ID=jitsi_test_instance
JWT_APP_SECRET=[APP_SECRET]
JWT_ACCEPTED_ISSUERS = [APP_ID]
```
See more in: https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/

I hope this is useful for you. Let me know if you want me to patch anything :)