### PR TITLE
Removing GO version from X-Mailer

### DIFF
--- a/www/go/base/mail/Message.php
+++ b/www/go/base/mail/Message.php
@@ -51,7 +51,7 @@ class Message extends \Swift_Message{
 		parent::__construct($subject, $body, $contentType, $charset);
 
     $headers = $this->getHeaders();
-    $headers->addTextHeader("X-Mailer", "Group-Office (" . go()->getVersion() . ")");
+    $headers->addTextHeader("X-Mailer", "Group-Office");
 
 		// See Mailer.php at line 105 for header encoding
 		if(GO::config()->swift_email_body_force_to_base64) {

--- a/www/go/core/mail/Message.php
+++ b/www/go/core/mail/Message.php
@@ -32,7 +32,7 @@ class Message extends \Swift_Message {
 		$this->setFrom(go()->getSettings()->systemEmail,go()->getSettings()->title);
 
         $headers = $this->getHeaders();
-		$headers->addTextHeader("X-Mailer", "Group-Office (" . go()->getVersion() . ")");
+		$headers->addTextHeader("X-Mailer", "Group-Office");
 	}
 
 	/**


### PR DESCRIPTION
As already written in issue #1017 it would be more sensitive to let others NOT know which version of GO is running, especially when the URL to the installation is also shown in the mail headers.