### PR TITLE
Fix for 'actionMoveToSpam' because of hardcoded 'Spam' folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 - Core/Email: Sent items didn't have BCC address header since v6.8
+- Email: Fix for 'actionMoveToSpam' because of hardcoded 'Spam' folder
+  Now you can define a global value: 'spam_folder' => 'INBOX.Junk' or
+   use its defined value in account settings (account->spam)
 
 20-11-2023: 6.8.20
 - Calendar: Don't try to match email if it's a reply

--- a/www/modules/email/controller/MessageController.php
+++ b/www/modules/email/controller/MessageController.php
@@ -2007,13 +2007,15 @@ Settings -> Accounts -> Double click account -> Folders.", "email");
 
 	protected function actionMoveToSpam(array $params)
 	{
-		
-		$accountModel = \GO\Email\Model\Account::model()->findByPk($params['account_id']);
-				
-		$imap = $accountModel->openImapConnection($params['from_mailbox_name']);
-		
-		$spamFolder = isset(GO::config()->spam_folder) ? GO::config()->spam_folder : 'Spam';
-		
+
+		$account = Account::model()->findByPk($params['account_id']);
+		$imap = $account->openImapConnection($params['from_mailbox_name']);
+		$spamFolder = isset(GO::config()->spam_folder) ? GO::config()->spam_folder : $account->spam;
+
+		if (empty($spamFolder)) {
+			throw new \Exception(GO::t("Could not get 'Spam' folder. Maybe it is disabled.\n\nGo to E-mail -> Administration -> Accounts -> Double click account -> Folders to configure it.", "email"));
+		}
+
 		if(!$imap->get_status($spamFolder)){
 			$imap->create_folder($spamFolder);
 		}


### PR DESCRIPTION
Moving Spam to Spam folder via Menu or link did not work because of **_hardcoded_** stuff.

Now you can define a global value, e.g.:
```
'spam_folder' => 'INBOX.UCE',
```

if not set the defined value from account is taken (account->spam)