### PR TITLE
Include sabre/dav iCalendar Export Plugin

### DIFF
--- a/www/modules/caldav/calendar.php
+++ b/www/modules/caldav/calendar.php
@@ -88,6 +88,10 @@ $server->addPlugin($authPlugin);
 $caldavPlugin = new Sabre\CalDAV\Plugin();
 $server->addPlugin($caldavPlugin);
 
+// iCalendar Export Plugin
+$icsPlugin = new Sabre\CalDAV\ICSExportPlugin();
+$server->addPlugin($icsPlugin);
+
 // ACL plugin
 $aclPlugin = new Sabre\DAVACL\Plugin();
 $aclPlugin->allowUnauthenticatedAccess = false;


### PR DESCRIPTION
Would be nice to have that feature, then whole calendars could be exported into an .ics-File :) 
I tested this change successfully in my docker environment.

_There are some Calendaring tools that don't yet support CalDAV, but they do have support for the 'Subscribe to' feature._
[iCalendar Export Plugin](https://sabre.io/dav/ics-export-plugin/)