### PR TITLE
Variable number of spaces before date

### DIFF
--- a/www/go/base/mail/Imap.php
+++ b/www/go/base/mail/Imap.php
@@ -1771,7 +1771,7 @@ class Imap extends ImapBodyStruct
 				return false;
 			}
 
-			if(preg_match('/INTERNALDATE ([^\s\)]+ [^\s\)]+ [^\s\)]+)/', $message, $dateMatches)) {
+			if(preg_match('/INTERNALDATE\s+([^\s\)]+ [^\s\)]+ [^\s\)]+)/', $message, $dateMatches)) {
 				$date = $dateMatches[1];
 			}else{
 				return false;


### PR DESCRIPTION
Fix IMAP INTERNALDATE regex for variable whitespace

The current regex expects exactly one space after INTERNALDATE, but
RFC 3501 allows variable whitespace. Newer Cyrus IMAP versions (3.8.6+)
use multiple spaces for single-digit dates, breaking the regex match.

Fixes Z-Push sync failures for some IMAP servers, Cyrus being one.