### PR TITLE
LDAP: add fallback to mailPrimaryAddress when determining user domain

### DIFF
--- a/www/go/modules/community/ldapauthenticator/cli/controller/Sync.php
+++ b/www/go/modules/community/ldapauthenticator/cli/controller/Sync.php
@@ -228,7 +228,18 @@ class Sync extends Controller
 			}
 		}
 
-		$mailDomain = isset($record->mail[0]) ? explode('@', $record->mail[0])[1] : null;
+		// Try to determine mail domain from common LDAP attributes.
+		// Some directories (e.g. UCS) use non-standard attributes like "mailPrimaryAddress".
+		$mail = null;
+
+		foreach (['mail', 'mailprimaryaddress'] as $attr) {
+        		if (!empty($record->{$attr}[0]) && str_contains($record->{$attr}[0], '@')) {
+                		$mail = $record->{$attr}[0];
+                		break;
+        		}
+		}
+
+		$mailDomain = $mail ? explode('@', $mail, 2)[1] : null;
 
 		if (empty($domain) || !in_array($domain, $this->domains)) {
 			go()->info("Using domain from mail property for " . $username);

--- a/www/go/modules/community/ldapauthenticator/cli/controller/Sync.php
+++ b/www/go/modules/community/ldapauthenticator/cli/controller/Sync.php
@@ -228,18 +228,29 @@ class Sync extends Controller
 			}
 		}
 
-		// Try to determine mail domain from common LDAP attributes.
-		// Some directories (e.g. UCS) use non-standard attributes like "mailPrimaryAddress".
+		// Determine email using LDAP mapping if available
+		$config = go()->getConfig();
+		$mapping = $config['ldapMapping'] ?? null;
+
 		$mail = null;
 
-		foreach (['mail', 'mailprimaryaddress'] as $attr) {
-        		if (!empty($record->{$attr}[0]) && str_contains($record->{$attr}[0], '@')) {
-                		$mail = $record->{$attr}[0];
-                		break;
+		if (isset($mapping['email'])) {
+        		if (is_callable($mapping['email'])) {
+                		$mail = $mapping['email']($record);
+        		} else {
+                		$attr = strtolower($mapping['email']);
+                		$mail = $record->{$attr}[0] ?? null;
         		}
 		}
 
-		$mailDomain = $mail ? explode('@', $mail, 2)[1] : null;
+		// Fallback to default LDAP mail attribute
+		if (!$mail) {
+        		$mail = $record->mail[0] ?? null;
+		}
+
+		$mailDomain = $mail && str_contains($mail, '@')
+        		? explode('@', $mail, 2)[1]
+        		: null;
 
 		if (empty($domain) || !in_array($domain, $this->domains)) {
 			go()->info("Using domain from mail property for " . $username);


### PR DESCRIPTION
When syncing LDAP users, GroupOffice determines the user domain from the DN and falls back to the LDAP "mail" attribute when the DN-derived domain is not configured.

Univention Corporate Server (UCS) stores the primary email address in "mailPrimaryAddress" instead of "mail".
This change keeps the existing behavior unchanged and adds "mailPrimaryAddress" as a fallback before failing.

Tested with LDAP setup where:
- DN-derived domain is ad.example.com
- configured GroupOffice domain is example.com
- LDAP user has mailPrimaryAddress but no mail attribute

Result:
- user sync/login creates user as username@example.com