### PR TITLE
Calendar: Correctly mapped CREATED and LAST-MODIFIED

### DIFF
--- a/www/go/modules/community/calendar/model/ICalendarHelper.php
+++ b/www/go/modules/community/calendar/model/ICalendarHelper.php
@@ -479,13 +479,32 @@ class ICalendarHelper {
 			$event->setValues((array)$obj); // title, description, start, duration, location, status, privacy
 			$event->prodId = $prodId;
 			$baseEvents[$event->uid] = $event;
-			if($event->isNew() && isset($vevent->{'DTSTAMP'})) {
-				try {$event->createdAt = $vevent->DTSTAMP->getDateTime();}
-				catch(VObject\InvalidDataException $e) {$event->createdAt = new \DateTime();}
+			if (isset($vevent->CREATED)) {
+				try {
+					$event->createdAt = $vevent->CREATED->getDateTime();
+				} catch (VObject\InvalidDataException $e) {
+					$event->createdAt = new \DateTime();
+				}
+			} else if ($event->isNew() && isset($vevent->DTSTAMP)) {
+				try {
+					$event->createdAt = $vevent->DTSTAMP->getDateTime();
+				} catch (VObject\InvalidDataException $e) {
+					$event->createdAt = new \DateTime();
+				}
 			}
-			if(isset($vevent->{'LAST-MODIFIED'})) {
-				try{$event->modifiedAt = $vevent->{'LAST-MODIFIED'}->getDateTime();}
-				catch(VObject\InvalidDataException $e) {$event->modifiedAt = new \DateTime(); }
+
+			if (isset($vevent->{'LAST-MODIFIED'})) {
+				try {
+					$event->modifiedAt = $vevent->{'LAST-MODIFIED'}->getDateTime();
+				} catch (VObject\InvalidDataException $e) {
+					$event->modifiedAt = new \DateTime();
+				}
+			} else if (isset($vevent->DTSTAMP)) {
+				try {
+					$event->modifiedAt = $vevent->DTSTAMP->getDateTime();
+				} catch (VObject\InvalidDataException $e) {
+					$event->modifiedAt = new \DateTime();
+				}
 			}
 			$event->showWithoutTime = !$vevent->DTSTART->hasTime();
 			if(isset($vevent->SEQUENCE))


### PR DESCRIPTION
fix(calendar): correct mapping of CREATED and LAST-MODIFIED in iCalendar parser

DTSTAMP represents the generation time of the iCalendar stream/record, NOT the event start (DTSTART) or creation (CREATED) timestamps.

- Fix bug where imorted/updated .ics events swapped or misapplied creation and modification timestamps, causing updated Gmail invitations to create duplicate entries instead of updating existing events.
- Read VEVENT `CREATED` property directly into `createdAt` if present (falling back to `DTSTAMP` for new events).
- Correctly map `LAST-MODIFIED` property to `modifiedAt` across all imports so event revision checks accurately identify existing records.